### PR TITLE
Switched package.json reference from azer's npm "img" module to azer's "img" git repo 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "async-each": "^0.1.6",
     "events": "^1.0.2",
-    "img": "^1.0.0"
+    "img": "^3.0.0"
   },
   "devDependencies": {
     "baboon-image-uri": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "async-each": "^0.1.6",
     "events": "^1.0.2",
-    "img": "^3.0.0"
+    "img": "git://github.com/npm-dom/img.git"
   },
   "devDependencies": {
     "baboon-image-uri": "^1.0.1",


### PR DESCRIPTION
Not sure if you want to accept this or not. Just one of the many 'azer' casualties. The img module is now being maintained by the dubious "kazmer" and has been bumped to version 3. It did not seem to work. 
I am not sure how sound of a strategy this is, but I just updated the package.json to use azer's git repo.
Seems his last update was a year ago. Funny enough, one of them was a pull request of yours.
https://github.com/npm-dom/img
